### PR TITLE
Avoid smart live always rebuild

### DIFF
--- a/dev-util/google-breakpad/google-breakpad-9999.ebuild
+++ b/dev-util/google-breakpad/google-breakpad-9999.ebuild
@@ -16,12 +16,21 @@ SLOT='0'
 KEYWORDS=''
 IUSE=''
 
-DEPEND=''
+DEPEND='
+	sys-libs/linux-syscall-support:=
+'
+RDEPEND=''
+
+# TODO remove bundled src/third_party
 
 src_unpack() {
-	local repo='https://chromium.googlesource.com/linux-syscall-support'
+	local lss="${S}/src/third_party/lss"
 
 	git-r3_src_unpack
-	git-r3_fetch "${repo}"
-	git-r3_checkout "${repo}" "${S}/src/third_party/lss"
+
+	mkdir "${lss}" || die "unable to create ${S}"
+	cp "${ROOT}/usr/include/linux_syscall_support.h" "${lss}" ||
+		die 'unable to copy linux_syscall_support.h'
+
+	default
 }

--- a/sys-libs/linux-syscall-support/linux-syscall-support-9999.ebuild
+++ b/sys-libs/linux-syscall-support/linux-syscall-support-9999.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit git-r3
+
+DESCRIPTION='Generally mirror libc but use direct syscalls'
+HOMEPAGE='https://chromium.googlesource.com/linux-syscall-support'
+SRC_URI=''
+EGIT_REPO_URI="https://chromium.googlesource.com/${PN}"
+
+LICENSE='Google-TOS'
+SLOT='0'
+KEYWORDS=''
+IUSE=''
+
+DEPEND=''
+RDEPEND=''
+
+DOCS=(
+	'README.md'
+)
+
+src_install() {
+	doheader *.h
+
+	default
+}

--- a/sys-libs/linux-syscall-support/metadata.xml
+++ b/sys-libs/linux-syscall-support/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<longdescription lang="en">
+	</longdescription>
+</pkgmetadata>


### PR DESCRIPTION
There is a bug in `smart-live-rebuild` which triggers a rebuild each time with `dev-util/google-breakpad`, fixed by having `sys-libs/linux-syscall-support` in the tree.